### PR TITLE
[ORG] RU-AXAV: Using TCK Tested JDK builds of OpenJDK (#7354)

### DIFF
--- a/.github/workflows/gradle_branch.yml
+++ b/.github/workflows/gradle_branch.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'zulu'
         java-version: '8'
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.6

--- a/.github/workflows/gradle_jdk11.yml
+++ b/.github/workflows/gradle_jdk11.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'zulu'
         java-version: '11'
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.6

--- a/.github/workflows/gradle_pr.yml
+++ b/.github/workflows/gradle_pr.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'zulu'
         java-version: '8'
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.6

--- a/.github/workflows/gradle_release.yml
+++ b/.github/workflows/gradle_release.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'zulu'
         java-version: '8'
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.6

--- a/.github/workflows/gradle_snapshot.yml
+++ b/.github/workflows/gradle_snapshot.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'zulu'
         java-version: '8'
     - name: Cache Gradle packages
       uses: actions/cache@v2.1.6


### PR DESCRIPTION
* Using the latest LTS and fixed (major) versions of the OpenJDK. Zulu builds are used b/c it supports archived JDK, LTS, and Non-LTS versions.

Signed-off-by: Carl Dea <carldea@gmail.com>

* Remove matrix and fixed versions of JDK that was used in setup-java GH actions.

Signed-off-by: Carl Dea <carldea@gmail.com>

Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [ ] Please give a description about what and why you are contributing, even if it's trivial.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
